### PR TITLE
Add dark mode toggle to website

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "serde",
  "serde_json",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ leptos_meta = { version = "0.6", features = ["csr"] }
 leptos_router = { version = "0.6", features = ["csr"] }
 console_error_panic_hook = "0.1"
 wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["Window", "Document", "HtmlElement", "Storage", "MediaQueryList"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 pulldown-cmark = "0.9"

--- a/src/components/nav.rs
+++ b/src/components/nav.rs
@@ -7,6 +7,66 @@ pub fn Nav() -> impl IntoView {
     let menu_items = get_menu_items();
     let socials = get_socials();
 
+    // Initialize theme from localStorage or system preference
+    let (is_dark, set_is_dark) = create_signal(false);
+
+    // Initialize theme on mount
+    create_effect(move |_| {
+        if let Some(window) = web_sys::window() {
+            if let Some(document) = window.document() {
+                if let Some(html) = document.document_element() {
+                    // Check localStorage first
+                    if let Ok(Some(storage)) = window.local_storage() {
+                        if let Ok(Some(theme)) = storage.get_item("theme") {
+                            let is_dark_mode = theme == "dark";
+                            set_is_dark.set(is_dark_mode);
+
+                            if is_dark_mode {
+                                let _ = html.class_list().add_1("dark");
+                            } else {
+                                let _ = html.class_list().remove_1("dark");
+                            }
+                            return;
+                        }
+                    }
+
+                    // Fall back to system preference
+                    if let Ok(media_query) = window.match_media("(prefers-color-scheme: dark)") {
+                        if let Some(mql) = media_query {
+                            if mql.matches() {
+                                set_is_dark.set(true);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // Toggle theme function
+    let toggle_theme = move |_| {
+        let new_theme = !is_dark.get();
+        set_is_dark.set(new_theme);
+
+        if let Some(window) = web_sys::window() {
+            if let Some(document) = window.document() {
+                if let Some(html) = document.document_element() {
+                    if new_theme {
+                        let _ = html.class_list().add_1("dark");
+                    } else {
+                        let _ = html.class_list().remove_1("dark");
+                    }
+                }
+            }
+
+            // Save to localStorage
+            if let Ok(Some(storage)) = window.local_storage() {
+                let theme_value = if new_theme { "dark" } else { "light" };
+                let _ = storage.set_item("theme", theme_value);
+            }
+        }
+    };
+
     view! {
         <nav class="nav">
             <div class="nav-container">
@@ -35,6 +95,15 @@ pub fn Nav() -> impl IntoView {
                             </a>
                         }
                     }).collect::<Vec<_>>()}
+
+                    <button
+                        class="theme-toggle"
+                        on:click=toggle_theme
+                        aria-label="Toggle dark mode"
+                        title="Toggle dark mode"
+                    >
+                        {move || if is_dark.get() { "☀" } else { "☾" }}
+                    </button>
                 </div>
             </div>
         </nav>

--- a/style.css
+++ b/style.css
@@ -37,6 +37,39 @@
     }
 }
 
+/* Dark mode override (when explicitly enabled) */
+html.dark {
+    --bg-0: #1a1a1a;
+    --bg-1: #212121;
+    --bg-2: #2a2a2a;
+    --text-0: #e0e0e0;
+    --text-1: #a0a0a0;
+    --text-2: #737373;
+    --border-color: #424242;
+    --primary-color: #CF9FFF;
+    --hover-color: #1a1a1a;
+    --highlight-color: #3d1f5c;
+}
+
+/* Theme toggle button */
+.theme-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+    color: var(--text-1);
+    font-size: 1.2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+}
+
+.theme-toggle:hover {
+    background-color: var(--primary-color);
+    color: var(--hover-color);
+}
+
 /* Reset */
 * {
     margin: 0;


### PR DESCRIPTION
Implements a theme toggle button in the navigation bar that allows users to switch between dark and light modes. The theme preference is persisted in localStorage and respects system preferences as a fallback.

Changes:
- Added theme toggle button to Nav component with moon/sun icons
- Implemented theme state management using Leptos signals
- Added localStorage persistence for theme preference
- Updated CSS with class-based dark mode override (.dark class)
- Added web-sys dependency for DOM and localStorage access
- Theme initialization checks localStorage first, then falls back to system preference

The toggle appears in the navigation bar next to social links and smoothly transitions between light and dark themes.