### PR TITLE
Fix direct URL access returning page not found

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Redirecting...</title>
+    <script>
+        // GitHub Pages SPA redirect solution
+        // This script captures the current path and redirects to index.html
+        // while preserving the path in sessionStorage so the client-side
+        // router can handle it
+        sessionStorage.redirect = location.pathname + location.search + location.hash;
+    </script>
+    <meta http-equiv="refresh" content="0;URL='/'">
+</head>
+<body>
+    <p>Redirecting...</p>
+</body>
+</html>

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -13,6 +13,10 @@ minify = "on_release"
 # Public URL from which assets are served
 public_url = "/"
 
+# Copy 404.html for GitHub Pages SPA support
+[[copy]]
+target = "404.html"
+
 [watch]
 # Paths to watch for changes
 watch = ["src", "Cargo.toml", "index.html"]

--- a/index.html
+++ b/index.html
@@ -23,6 +23,16 @@
 </head>
 <body>
     <script>
+        // GitHub Pages SPA redirect handling
+        // Check if we were redirected from 404.html
+        (function() {
+            var redirect = sessionStorage.redirect;
+            delete sessionStorage.redirect;
+            if (redirect && redirect !== location.pathname) {
+                history.replaceState(null, null, redirect);
+            }
+        })();
+
         // Track SPA page views on route changes
         (function() {
             var lastPath = window.location.pathname;


### PR DESCRIPTION
Add 404.html redirect solution to handle direct URL access for SPA routes. When users directly access URLs like /posts/ps2, GitHub Pages will now:
1. Serve 404.html which saves the path to sessionStorage
2. Redirect to index.html
3. Restore the original path using history.replaceState
4. Let the Leptos router handle the routing

This fixes the issue where direct URL access returns "page not found" errors while navigation from the root site works correctly.