### PR TITLE
[codex] Add CodeCanvas playground

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,5 +1,6 @@
 ---
 const menuItems = [
+  { name: "/playground", url: "/playground" },
   { name: "/photos", url: "/photos" },
   { name: "/projects", url: "/projects" },
   { name: "/impact", url: "/impact" },

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -1,0 +1,502 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="CodeCanvas Playground | Cameron Durham" description="Run small code snippets from Cameron Durham's personal site through the CodeCanvas backend.">
+  <section class="play-shell" data-codecanvas-runner>
+    <header class="play-header">
+      <div>
+        <p class="eyebrow">CodeCanvas</p>
+        <h1>Playground</h1>
+      </div>
+      <div class="status-strip" aria-live="polite">
+        <span class="status-dot" data-status-dot></span>
+        <span data-status-label>Connecting</span>
+      </div>
+    </header>
+
+    <section class="runner-grid">
+      <div class="toolbar" aria-label="Runner controls">
+        <div class="connection-badge" aria-label="Execution backend">
+          <span>Runner</span>
+          <strong>CodeCanvas</strong>
+        </div>
+
+        <label class="field field-language">
+          <span>Language</span>
+          <select data-language disabled>
+            <option>loading</option>
+          </select>
+        </label>
+
+        <button class="secondary-button" type="button" data-reset>Reset</button>
+        <button class="run-button" type="button" data-run>Run</button>
+      </div>
+
+      <section class="editor-pane" aria-label="Source editor">
+        <div class="pane-title">
+          <span>Source</span>
+          <span data-source-meta>bash</span>
+        </div>
+        <textarea data-source spellcheck="false"></textarea>
+      </section>
+
+      <section class="output-pane" aria-label="Run output">
+        <div class="tabs" role="tablist" aria-label="Output streams">
+          <button class="tab active" type="button" data-output-tab="stdout">stdout</button>
+          <button class="tab" type="button" data-output-tab="stderr">stderr</button>
+          <button class="tab" type="button" data-output-tab="error">error</button>
+        </div>
+        <pre data-output data-active-output="stdout"></pre>
+      </section>
+    </section>
+  </section>
+
+<script>
+  const root = document.querySelector('[data-codecanvas-runner]');
+
+  if (root) {
+    const apiBaseUrl = 'https://runner.fly.dev';
+    const languageSelect = root.querySelector('[data-language]');
+    const sourceInput = root.querySelector('[data-source]');
+    const sourceMeta = root.querySelector('[data-source-meta]');
+    const runButton = root.querySelector('[data-run]');
+    const resetButton = root.querySelector('[data-reset]');
+    const output = root.querySelector('[data-output]');
+    const statusDot = root.querySelector('[data-status-dot]');
+    const statusLabel = root.querySelector('[data-status-label]');
+    const outputTabs = Array.from(root.querySelectorAll('[data-output-tab]'));
+
+    const state = {
+      activeOutput: 'stdout',
+      outputs: {
+        stdout: '',
+        stderr: '',
+        error: '',
+      },
+      languages: [],
+    };
+
+    const examples = {
+      bash: 'echo "hello from CodeCanvas"\nprintf "today: "\ndate -u +"%Y-%m-%dT%H:%M:%SZ"',
+      sh: 'echo "hello from CodeCanvas"\nprintf "shell: "\necho "$0"',
+      python: 'items = ["code", "canvas", "play"]\nfor index, item in enumerate(items, 1):\n    print(f"{index}: {item}")',
+      python3: 'items = ["code", "canvas", "play"]\nfor index, item in enumerate(items, 1):\n    print(f"{index}: {item}")',
+      javascript: 'const values = ["code", "canvas", "play"];\nvalues.forEach((value, index) => console.log(`${index + 1}: ${value}`));',
+      js: 'const values = ["code", "canvas", "play"];\nvalues.forEach((value, index) => console.log(`${index + 1}: ${value}`));',
+      node: 'const values = ["code", "canvas", "play"];\nvalues.forEach((value, index) => console.log(`${index + 1}: ${value}`));',
+      nodejs: 'const values = ["code", "canvas", "play"];\nvalues.forEach((value, index) => console.log(`${index + 1}: ${value}`));',
+      go: 'package main\n\nimport "fmt"\n\nfunc main() {\n    fmt.Println("hello from CodeCanvas")\n}',
+      rust: 'fn main() {\n    println!("hello from CodeCanvas");\n}',
+      'c++': '#include <iostream>\n\nint main() {\n    std::cout << "hello from CodeCanvas" << std::endl;\n    return 0;\n}',
+      cpp: '#include <iostream>\n\nint main() {\n    std::cout << "hello from CodeCanvas" << std::endl;\n    return 0;\n}',
+    };
+
+    const normalizeLanguage = (language) => language.trim().toLowerCase();
+    const setStatus = (kind, label) => {
+      statusDot.dataset.status = kind;
+      statusLabel.textContent = label;
+    };
+
+    const setOutput = (stream, value) => {
+      state.outputs[stream] = value || '';
+      if (state.activeOutput === stream) {
+        output.textContent = state.outputs[stream];
+      }
+    };
+
+    const renderActiveOutput = () => {
+      outputTabs.forEach((tab) => {
+        const isActive = tab.dataset.outputTab === state.activeOutput;
+        tab.classList.toggle('active', isActive);
+        tab.setAttribute('aria-selected', String(isActive));
+      });
+      output.dataset.activeOutput = state.activeOutput;
+      output.textContent = state.outputs[state.activeOutput] || '';
+    };
+
+    const exampleFor = (language) => {
+      const normalized = normalizeLanguage(language);
+      return examples[normalized] || `print("hello from ${language}")`;
+    };
+
+    const applyExample = () => {
+      const language = languageSelect.value || 'bash';
+      sourceInput.value = exampleFor(language);
+      sourceMeta.textContent = language;
+    };
+
+    const resetOutputs = () => {
+      setOutput('stdout', '');
+      setOutput('stderr', '');
+      setOutput('error', '');
+    };
+
+    const loadLanguages = async () => {
+      setStatus('loading', 'Loading languages');
+      languageSelect.disabled = true;
+      resetOutputs();
+
+      try {
+        const response = await fetch(`${apiBaseUrl}/api/v1/languages`);
+        const data = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data.error || `request failed: ${response.status}`);
+        }
+
+        state.languages = Array.isArray(data.languages) ? data.languages : [];
+        languageSelect.replaceChildren(
+          ...state.languages.map((language) => {
+            const option = document.createElement('option');
+            option.value = language;
+            option.textContent = language;
+            return option;
+          }),
+        );
+
+        if (state.languages.length === 0) {
+          const option = document.createElement('option');
+          option.textContent = 'none';
+          languageSelect.replaceChildren(option);
+          setStatus('error', 'No languages');
+          return;
+        }
+
+        const preferred = state.languages.includes('bash') ? 'bash' : state.languages[0];
+        languageSelect.value = preferred;
+        languageSelect.disabled = false;
+        applyExample();
+        setStatus('ready', 'Ready');
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'unknown request error';
+        languageSelect.replaceChildren(new Option('unavailable', ''));
+        setOutput('error', message);
+        state.activeOutput = 'error';
+        renderActiveOutput();
+        setStatus('error', 'Backend unavailable');
+      }
+    };
+
+    const runCode = async () => {
+      runButton.disabled = true;
+      languageSelect.disabled = true;
+      resetOutputs();
+      setStatus('loading', 'Running');
+
+      try {
+        const response = await fetch(`${apiBaseUrl}/api/v1/run`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            language: languageSelect.value,
+            source: sourceInput.value,
+          }),
+        });
+        const data = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data.error || `request failed: ${response.status}`);
+        }
+
+        setOutput('stdout', data.stdout || '');
+        setOutput('stderr', data.stderr || '');
+        setOutput('error', data.error || '');
+        state.activeOutput = data.error ? 'error' : data.stderr ? 'stderr' : 'stdout';
+        setStatus(data.error ? 'error' : 'ready', data.error ? 'Runtime error' : 'Finished');
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'unknown request error';
+        setOutput('error', message);
+        state.activeOutput = 'error';
+        setStatus('error', 'Request failed');
+      } finally {
+        renderActiveOutput();
+        runButton.disabled = false;
+        languageSelect.disabled = state.languages.length === 0;
+      }
+    };
+
+    outputTabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        state.activeOutput = tab.dataset.outputTab;
+        renderActiveOutput();
+      });
+    });
+
+    languageSelect.addEventListener('change', () => {
+      resetOutputs();
+      applyExample();
+    });
+    resetButton.addEventListener('click', () => {
+      resetOutputs();
+      applyExample();
+      state.activeOutput = 'stdout';
+      renderActiveOutput();
+    });
+    runButton.addEventListener('click', () => {
+      void runCode();
+    });
+    renderActiveOutput();
+    void loadLanguages();
+  }
+</script>
+</BaseLayout>
+
+<style>
+.play-shell {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.play-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 0.9rem;
+}
+
+.play-header h1 {
+  margin: 0.1rem 0 0;
+}
+
+.play-header h1::before {
+  content: none;
+}
+
+.eyebrow {
+  color: var(--text-2);
+  font-family: var(--mono-text-font);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.status-strip {
+  align-items: center;
+  background: var(--bg-1);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  color: var(--text-1);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-family: var(--mono-text-font);
+  font-size: 0.8rem;
+  gap: 0.45rem;
+  min-height: 2rem;
+  padding: 0.3rem 0.7rem;
+}
+
+.status-dot {
+  background: var(--text-2);
+  border-radius: 999px;
+  display: inline-block;
+  height: 0.55rem;
+  width: 0.55rem;
+}
+
+.status-dot[data-status="ready"] {
+  background: #168a4a;
+}
+
+.status-dot[data-status="loading"] {
+  background: #a66b00;
+}
+
+.status-dot[data-status="error"] {
+  background: #be2f36;
+}
+
+.runner-grid {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  overflow: hidden;
+}
+
+.toolbar {
+  align-items: end;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--border-color);
+  display: grid;
+  gap: 0.7rem;
+  grid-column: 1 / -1;
+  grid-template-columns: minmax(180px, 1fr) minmax(140px, 0.35fr) auto auto;
+  padding: 0.75rem;
+}
+
+.connection-badge {
+  align-items: center;
+  align-self: stretch;
+  background: var(--bg-0);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  display: flex;
+  justify-content: space-between;
+  min-height: 2.35rem;
+  padding: 0.45rem 0.65rem;
+}
+
+.connection-badge span {
+  color: var(--text-2);
+  font-family: var(--mono-text-font);
+  font-size: 0.78rem;
+}
+
+.connection-badge strong {
+  color: var(--text-0);
+  font-size: 0.92rem;
+  font-weight: 500;
+}
+
+.field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.field span,
+.pane-title {
+  color: var(--text-2);
+  font-family: var(--mono-text-font);
+  font-size: 0.78rem;
+}
+
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+select {
+  background: var(--bg-0);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-0);
+  min-height: 2.35rem;
+  padding: 0.45rem 0.55rem;
+}
+
+button {
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  cursor: pointer;
+  min-height: 2.35rem;
+  padding: 0.45rem 0.75rem;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.run-button {
+  background: var(--primary-color);
+  color: var(--hover-color);
+}
+
+.secondary-button {
+  background: var(--bg-0);
+  color: var(--text-0);
+}
+
+.editor-pane,
+.output-pane {
+  display: grid;
+  grid-template-rows: auto minmax(420px, 56vh);
+  min-width: 0;
+}
+
+.editor-pane {
+  border-right: 1px solid var(--border-color);
+}
+
+.pane-title {
+  align-items: center;
+  background: var(--bg-0);
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  min-height: 2.4rem;
+  padding: 0.45rem 0.75rem;
+}
+
+textarea {
+  background: var(--bg-0);
+  border: 0;
+  color: var(--text-0);
+  font-family: var(--code-font);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  min-height: 0;
+  outline: none;
+  padding: 0.9rem;
+  resize: none;
+  width: 100%;
+}
+
+.tabs {
+  background: var(--bg-0);
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  min-height: 2.4rem;
+}
+
+.tab {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  color: var(--text-1);
+  min-height: 2.4rem;
+}
+
+.tab.active {
+  background: var(--bg-1);
+  color: var(--text-0);
+}
+
+.output-pane pre {
+  background: var(--bg-0) !important;
+  border: 0;
+  border-radius: 0;
+  color: var(--text-0);
+  font-size: 0.9rem;
+  margin: 0;
+  min-height: 0;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+
+.output-pane pre[data-active-output="stderr"] {
+  color: #a66b00;
+}
+
+.output-pane pre[data-active-output="error"] {
+  color: #be2f36;
+}
+
+@media (max-width: 780px) {
+  .play-header {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .runner-grid,
+  .toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .editor-pane,
+  .output-pane {
+    grid-template-rows: auto minmax(280px, 42vh);
+  }
+
+  .editor-pane {
+    border-bottom: 1px solid var(--border-color);
+    border-right: 0;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary

Adds a native `/playground` page to the personal site that exposes the CodeCanvas code executor without reinstating the old `/codecanvas` proxy. The page loads supported languages from the production runner backend, provides language-specific starter snippets, runs code through `POST /api/v1/run`, and displays stdout, stderr, and runtime errors in separate tabs.

The backend target is presented as a polished CodeCanvas runner connection instead of a raw API URL field. `/playground` is also added to the site navigation.

## Validation

- `npm run build`
- `git diff --check`
- `rg -n "/play|CodeCanvas Play|data-api-base|apiBaseInput" src || true`
- `rg -n "https://u64.cam/play|/playground|Backend|Runner" dist/sitemap-0.xml dist/playground/index.html dist/index.html`
- `curl -fsSL https://runner.fly.dev/api/v1/languages`
- `curl -fsSL -X POST https://runner.fly.dev/api/v1/run -H 'Content-Type: application/json' -d '{"language":"bash","source":"echo personal-site-codecanvas-ok"}'`
- `curl -fsSL -X POST https://runner.fly.dev/api/v1/run -H 'Content-Type: application/json' -d '{"language":"nodejs","source":"console.log(\"nodejs-example-ok\")"}'`


## Manual Testing

<img width="1080" height="1065" alt="image" src="https://github.com/user-attachments/assets/762ed861-24a8-41f7-9457-800531abdea1" />
