### PR TITLE
[codex] Add WHOOP privacy and callback pages

### DIFF
--- a/src/pages/privacy/whoop.astro
+++ b/src/pages/privacy/whoop.astro
@@ -1,0 +1,68 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="WHOOP Privacy Policy | Cameron Durham"
+  description="Privacy policy for Cameron Durham's personal WHOOP stats integration."
+>
+  <section>
+    <h1>WHOOP Privacy Policy</h1>
+    <p><time datetime="2026-05-03">Last updated: May 3, 2026</time></p>
+    <p>
+      This privacy policy applies to <code>u64.cam-personal-stats</code>, a personal
+      integration built and operated by Cameron Durham.
+    </p>
+
+    <h2>What This App Does</h2>
+    <p>
+      This app connects to WHOOP through OAuth so Cameron Durham can view personal
+      wellness and activity data in custom dashboards and local tools.
+    </p>
+
+    <h2>Data Collected</h2>
+    <p>
+      Depending on the scopes granted, the app may access profile, recovery, sleep,
+      cycle, workout, and body measurement data from WHOOP.
+    </p>
+
+    <h2>How Data Is Used</h2>
+    <p>
+      Data is used only to display, analyze, and store Cameron Durham&apos;s own WHOOP
+      statistics for personal use. It is not used for advertising, resale, or data
+      brokerage.
+    </p>
+
+    <h2>Storage</h2>
+    <p>
+      OAuth tokens and synced WHOOP data may be stored on systems controlled by
+      Cameron Durham, including local development environments and personal cloud
+      infrastructure used to host private tools.
+    </p>
+
+    <h2>Sharing</h2>
+    <p>
+      Data is not sold or shared with third parties except when necessary to operate
+      the underlying hosting, storage, or infrastructure services used by Cameron
+      Durham.
+    </p>
+
+    <h2>Retention And Deletion</h2>
+    <p>
+      Access can be revoked at any time through WHOOP or by contacting Cameron
+      Durham. Stored tokens or synced data can be deleted upon request.
+    </p>
+
+    <h2>Security</h2>
+    <p>
+      Reasonable steps are taken to protect OAuth credentials and stored data, but
+      no system can guarantee absolute security.
+    </p>
+
+    <h2>Contact</h2>
+    <p>
+      For questions or deletion requests, contact
+      <a href="mailto:u64.cam@gmail.com">u64.cam@gmail.com</a>.
+    </p>
+  </section>
+</BaseLayout>

--- a/src/pages/whoop/callback.astro
+++ b/src/pages/whoop/callback.astro
@@ -1,0 +1,76 @@
+---
+const localCallback = 'http://127.0.0.1:4318/oauth/callback';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex,nofollow" />
+    <meta name="referrer" content="no-referrer" />
+    <title>WHOOP Callback Bridge</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: #111;
+        color: #f4f4f4;
+        padding: 24px;
+      }
+
+      main {
+        max-width: 720px;
+        width: 100%;
+        border: 1px solid #333;
+        border-radius: 12px;
+        padding: 24px;
+        background: #181818;
+      }
+
+      code,
+      a {
+        color: #9ad1ff;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>WHOOP Callback Bridge</h1>
+      <p id="status">Forwarding WHOOP authorization response to the local app.</p>
+      <p>
+        If you are not redirected automatically, make sure your local WHOOP app is
+        running on <code>http://127.0.0.1:4318</code>.
+      </p>
+      <p>
+        <a id="manual-link" href={localCallback}>Open local callback manually</a>
+      </p>
+    </main>
+
+    <script is:inline define:vars={{ localCallback }}>
+      const target = new URL(localCallback);
+      target.search = window.location.search;
+
+      const manualLink = document.getElementById('manual-link');
+      const status = document.getElementById('status');
+
+      if (manualLink) {
+        manualLink.href = target.toString();
+      }
+
+      if (window.location.search) {
+        status.textContent = 'Forwarding complete. If the local app does not open, use the manual link below.';
+        window.location.replace(target.toString());
+      } else {
+        status.textContent = 'No WHOOP authorization parameters were provided to this page.';
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What changed
Adds two public pages for the WHOOP personal-stats integration:

- a privacy policy page at `/privacy/whoop`
- a standalone OAuth callback bridge at `/whoop/callback`

## Why
WHOOP app registration requires a privacy policy URL and a registered HTTPS redirect URL. The callback bridge lets WHOOP redirect to `u64.cam` first and then forward the OAuth query string to the local development app running on `127.0.0.1:4318`.

## Risk / impact
The callback page is intentionally isolated from the site layout so it does not load analytics, external fonts, or other third-party assets before forwarding the OAuth response.

## Validation
- `npm run build`