### PR TITLE
feat: integrate photos and recent work across the site

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -18,6 +18,12 @@ const projects = defineCollection({
     description: z.string(),
     weight: z.number(),
     link: z.string().optional(),
+    status: z.string().optional(),
+    featured: z.boolean().default(false),
+    tags: z.array(z.string()).default([]),
+    image_url: z.string().optional(),
+    related_note: z.string().optional(),
+    related_photo: z.string().optional(),
   }),
 });
 
@@ -29,6 +35,12 @@ const photos = defineCollection({
     image_url: z.string(),
     link: z.string(),
     weight: z.number(),
+    year: z.string().optional(),
+    location: z.string().optional(),
+    story: z.string().optional(),
+    tags: z.array(z.string()).default([]),
+    related_project: z.string().optional(),
+    related_note: z.string().optional(),
   }),
 });
 
@@ -59,6 +71,10 @@ const notes = defineCollection({
     date: z.string(),
     summary: z.string(),
     tags: z.array(z.string()).default([]),
+    featured: z.boolean().default(false),
+    hero_image_url: z.string().optional(),
+    related_project: z.string().optional(),
+    related_photo: z.string().optional(),
   }),
 });
 

--- a/src/content/notes/orbit-on-nixos-unofficial.md
+++ b/src/content/notes/orbit-on-nixos-unofficial.md
@@ -3,6 +3,8 @@ title: "Running OrBit on NixOS for My Polestar 2 (Unofficial)"
 date: "2026-02-28"
 summary: "Why I built a small Nix+Wine wrapper for OrBit, what it does, and where to find the scripts."
 tags: ["nixos", "wine", "polestar", "automotive", "experiments"]
+featured: true
+related_project: "orbit-runner-flake"
 ---
 
 I wanted a repeatable way to run OrBit on my NixOS laptop and couldn't find a setup I trusted, so I wrote a small wrapper around Wine and a few network helpers.

--- a/src/content/photos/architecture-1.md
+++ b/src/content/photos/architecture-1.md
@@ -4,4 +4,7 @@ description: "Manhattan Office Space (shared under Unsplash License)"
 image_url: "https://images.unsplash.com/photo-1703537804519-ccc1aa0f212d?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
 link: "https://unsplash.com/photos/a-very-tall-building-lit-up-at-night-sLtoWdA1PWc"
 weight: 5
+location: "Manhattan"
+story: "Hard lines, window grids, and a compressed frame that feels closer to interface design than travel photography."
+tags: ["architecture", "grid", "night", "city"]
 ---

--- a/src/content/photos/landscape-1.md
+++ b/src/content/photos/landscape-1.md
@@ -4,4 +4,7 @@ description: "Cliffs of Moher, Ireland"
 image_url: "https://images.unsplash.com/photo-1600307736977-f8ef93ab19f3?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&fit=crop"
 link: "https://unsplash.com/photos/gray-rocky-mountain-with-green-grass-5Fw46YFc03s"
 weight: 4
+location: "Cliffs of Moher"
+story: "A wide, quiet frame that breaks up the site's systems-heavy work with actual horizon and weather."
+tags: ["landscape", "coast", "travel", "atmosphere"]
 ---

--- a/src/content/photos/sphere.md
+++ b/src/content/photos/sphere.md
@@ -4,4 +4,6 @@ description: "Still life tests (shared under Unsplash License)"
 image_url: "https://images.unsplash.com/photo-1607166291450-6956e8ad1719?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1471&q=80"
 link: "https://unsplash.com/photos/mRoO9w08evU"
 weight: 1
+story: "A study in reflections and synthetic surfaces. This is the visual lane that pairs best with tooling, interfaces, and machine-focused writing."
+tags: ["still-life", "reflection", "glass", "study"]
 ---

--- a/src/content/photos/still-1.md
+++ b/src/content/photos/still-1.md
@@ -4,4 +4,6 @@ description: "blue acryllic sphere (shared under Unsplash License)"
 image_url: "https://images.unsplash.com/photo-1607166291254-0b493edab3e4?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
 link: "https://unsplash.com/photos/black-ball-on-blue-sky-c9WkEaPBqLI"
 weight: 2
+story: "Simple object, strong color, no clutter. Good reference material for lighter hero treatments and cleaner card layouts."
+tags: ["still-life", "color", "minimal", "object"]
 ---

--- a/src/content/photos/still-4.md
+++ b/src/content/photos/still-4.md
@@ -4,4 +4,6 @@ description: "Acryllic Monolith (shared under Unsplash License)"
 image_url: "https://images.unsplash.com/photo-1628405242556-ed887753ff35?q=80&w=1429&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
 link: "https://unsplash.com/photos/black-and-gray-box-on-white-surface-mBmKi1MHsn8"
 weight: 2
+story: "A precise, almost product-shot composition. Useful as a bridge between photography and the cleaner engineering side of the site."
+tags: ["still-life", "product", "minimal", "shape"]
 ---

--- a/src/content/photos/twilight-epiphany.md
+++ b/src/content/photos/twilight-epiphany.md
@@ -4,4 +4,7 @@ description: "James Turrell Twilight Epiphany at Rice University (shared under U
 image_url: "https://images.unsplash.com/photo-1600047050118-8671c626b333?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80"
 link: "https://unsplash.com/photos/E57BNhGGaGA"
 weight: 1
+location: "Rice University"
+story: "Light, geometry, and color shifts in one frame. It sets the tone for the more playful side of the site better than a generic hero banner would."
+tags: ["light", "installation", "architecture", "night"]
 ---

--- a/src/content/projects/cfs-rs.md
+++ b/src/content/projects/cfs-rs.md
@@ -4,4 +4,6 @@ date: "2020-01-01"
 description: "Completely Fair Scheduler implementation in Rust"
 weight: 3
 link: "https://github.com/camerondurham/cfs-rs"
+status: "archive"
+tags: ["rust", "systems", "scheduler"]
 ---

--- a/src/content/projects/ch.md
+++ b/src/content/projects/ch.md
@@ -4,4 +4,7 @@ date: "2021-01-01"
 description: "Docker config and shell manager for using containers as ad-hoc dev environments"
 weight: 1
 link: "https://github.com/camerondurham/ch"
+status: "maintained"
+featured: true
+tags: ["containers", "shell", "go", "developer-tools"]
 ---

--- a/src/content/projects/cs350-docker.md
+++ b/src/content/projects/cs350-docker.md
@@ -4,4 +4,6 @@ date: "2020-01-01"
 description: "Containerized development environment for USC CS104"
 weight: 2
 link: "https://github.com/csci104/docker"
+status: "archive"
+tags: ["docker", "teaching", "developer-experience"]
 ---

--- a/src/content/projects/orbit-runner-flake.md
+++ b/src/content/projects/orbit-runner-flake.md
@@ -1,0 +1,11 @@
+---
+title: "orbit-runner-flake"
+date: "2026-02-28"
+description: "Unofficial NixOS and Wine wrapper for running OrBit with a repeatable workflow, backup step, and rollback path."
+weight: 0
+link: "https://github.com/camerondurham/orbit-runner-flake"
+status: "active"
+featured: true
+tags: ["nixos", "wine", "automotive", "experiments"]
+related_note: "orbit-on-nixos-unofficial"
+---

--- a/src/content/projects/polestar-api-rs.md
+++ b/src/content/projects/polestar-api-rs.md
@@ -1,0 +1,11 @@
+---
+title: "polestar-api-rs"
+date: "2026-03-22"
+description: "Rust wrapper around Polestar vehicle APIs for fetching data from my EV and understanding the surface area of the platform."
+weight: 0
+link: "https://github.com/camerondurham/polestar-api-rs"
+status: "active"
+featured: true
+tags: ["rust", "automotive", "api", "ev"]
+related_note: "orbit-on-nixos-unofficial"
+---

--- a/src/content/projects/runner.md
+++ b/src/content/projects/runner.md
@@ -4,4 +4,6 @@ date: "2020-01-01"
 description: "Code execution engine with Docker"
 weight: 4
 link: "https://github.com/camerondurham/runner"
+status: "archive"
+tags: ["docker", "execution", "backend"]
 ---

--- a/src/content/projects/stack-overflow-client.md
+++ b/src/content/projects/stack-overflow-client.md
@@ -4,4 +4,6 @@ date: "2020-01-01"
 description: "CLI client for Stack Overflow"
 weight: 5
 link: "https://github.com/camerondurham/stack-overflow-client"
+status: "archive"
+tags: ["rust", "cli", "api"]
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,22 +1,397 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+
+const allProjects = await getCollection('projects');
+const allNotes = await getCollection('notes');
+const allPhotos = await getCollection('photos');
+
+const featuredProjects = allProjects
+  .filter((project) => project.data.featured)
+  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
+  .slice(0, 3);
+
+const featuredNotes = allNotes
+  .filter((note) => note.data.featured)
+  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
+  .slice(0, 2);
+
+const featuredPhotos = [...allPhotos]
+  .sort((a, b) => a.data.weight - b.data.weight)
+  .slice(0, 3);
+
+const heroPhoto = featuredPhotos[0];
 ---
 
 <BaseLayout title="Cameron Durham" description="Cameron Durham - SDE II at Amazon">
-  <section class="about">
-    <h1>About</h1>
-    <p>
-      I'm an SDE II at Amazon, working on catalog indexing for the third-party seller listing platform.
-      I contributed to the <a href="https://www.aboutamazon.com/news/retail/affordable-products-amazon-20-dollars-and-under" target="_blank">Amazon Haul</a> listing experience and work with streaming data processing for distributed search indexing.
-      I also contribute to <a href="https://github.com/camerondurham/open-source-contributions" target="_blank">open-source projects</a> I use.
-    </p>
-    <p>
-      Previously, I was a lead course producer for <a href="https://bytes.usc.edu/cs104/" target="_blank">USC's CS104 class</a>, developing <a href="https://github.com/csci104/docker" target="_blank">containerized tools</a> for the class environment. I interned at Tesla, where I worked on containerized infotainment UIs for all Tesla car models. Before Tesla, I had internships at Amazon and Oracle.
-    </p>
+  <section class="hero">
+    <div class="hero-copy">
+      <p class="eyebrow">Software, systems, and visual obsessions</p>
+      <h1>Cameron Durham</h1>
+      <p class="lede">
+        I build software for distributed systems and spend a lot of my spare time around developer tools,
+        Linux workflows, odd automotive experiments, and image-heavy side quests.
+      </p>
+      <p>
+        I'm an SDE II at Amazon, working on catalog indexing for the third-party seller listing platform.
+        I contributed to the <a href="https://www.aboutamazon.com/news/retail/affordable-products-amazon-20-dollars-and-under" target="_blank">Amazon Haul</a> listing experience and work with streaming data processing for distributed search indexing.
+        I also contribute to <a href="https://github.com/camerondurham/open-source-contributions" target="_blank">open-source projects</a> I use.
+      </p>
+      <p>
+        Previously, I was a lead course producer for <a href="https://bytes.usc.edu/cs104/" target="_blank">USC's CS104 class</a>, developing <a href="https://github.com/csci104/docker" target="_blank">containerized tools</a> for the class environment. I interned at Tesla, where I worked on containerized infotainment UIs for all Tesla car models. Before Tesla, I had internships at Amazon and Oracle.
+      </p>
+      <div class="hero-actions">
+        <a href="/projects">Recent Experiments</a>
+        <a href="/notes">Engineering Notes</a>
+        <a href="/photos">Visual Notebook</a>
+      </div>
+    </div>
+
+    {heroPhoto && (
+      <a href={`/photos#${heroPhoto.slug}`} class="hero-visual">
+        <img src={heroPhoto.data.image_url} alt={heroPhoto.data.title} loading="eager" />
+        <div class="hero-visual-copy">
+          <span class="hero-visual-label">Visual notebook</span>
+          <strong>{heroPhoto.data.title}</strong>
+          {heroPhoto.data.story && <p>{heroPhoto.data.story}</p>}
+        </div>
+      </a>
+    )}
+  </section>
+
+  <section class="now-strip">
+    <article>
+      <span>Current themes</span>
+      <p>Rust utilities, Nix wrappers, vehicle APIs, and making room for more images across the site.</p>
+    </article>
+    <article>
+      <span>What changed recently</span>
+      <p>Public work lately has centered on <code>polestar-api-rs</code>, <code>orbit-runner-flake</code>, and fresh notes about experimental workflows.</p>
+    </article>
+    <article>
+      <span>Why the photos matter</span>
+      <p>The visual side keeps the site from collapsing into a pure resume. It gives the engineering work atmosphere and memory.</p>
+    </article>
+  </section>
+
+  <section class="section-block">
+    <div class="section-heading">
+      <h2>Recent Experiments</h2>
+      <a href="/projects">See all projects</a>
+    </div>
+    <div class="feature-grid">
+      {featuredProjects.map((project) => (
+        <article class="feature-card" id={`project-${project.slug}`}>
+          <div class="feature-card-top">
+            <p class="meta-line">
+              <time datetime={project.data.date}>{project.data.date}</time>
+              {project.data.status && <span class="status-pill">{project.data.status}</span>}
+            </p>
+            <h3>
+              {project.data.link ? (
+                <a href={project.data.link} target="_blank" rel="noopener noreferrer">{project.data.title}</a>
+              ) : (
+                project.data.title
+              )}
+            </h3>
+          </div>
+          <p>{project.data.description}</p>
+          {project.data.tags.length > 0 && (
+            <div class="pill-row">
+              {project.data.tags.map((tag) => <span class="pill">{tag}</span>)}
+            </div>
+          )}
+          {project.data.related_note && (
+            <p class="related-link">
+              Related note:
+              <a href={`/notes/${project.data.related_note}`}>{allNotes.find((note) => note.slug === project.data.related_note)?.data.title}</a>
+            </p>
+          )}
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section class="section-block">
+    <div class="section-heading">
+      <h2>Field Notes</h2>
+      <a href="/notes">Browse notes</a>
+    </div>
+    <div class="notes-grid">
+      {featuredNotes.map((note) => (
+        <article class="note-card">
+          <time datetime={note.data.date}>{note.data.date}</time>
+          <h3><a href={`/notes/${note.slug}`}>{note.data.title}</a></h3>
+          <p>{note.data.summary}</p>
+          {note.data.tags.length > 0 && (
+            <div class="pill-row">
+              {note.data.tags.map((tag) => <span class="pill">{tag}</span>)}
+            </div>
+          )}
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section class="section-block">
+    <div class="section-heading">
+      <h2>Visual Notebook</h2>
+      <a href="/photos">Open gallery</a>
+    </div>
+    <div class="photo-ribbon">
+      {featuredPhotos.map((photo) => (
+        <a href={`/photos#${photo.slug}`} class="ribbon-card">
+          <img src={photo.data.image_url} alt={photo.data.title} loading="lazy" />
+          <div class="ribbon-copy">
+            <strong>{photo.data.title}</strong>
+            <span>{photo.data.location ?? photo.data.description}</span>
+          </div>
+        </a>
+      ))}
+    </div>
   </section>
 </BaseLayout>
 
 <style>
-.about { margin-bottom: 2rem; }
-.about p { margin-bottom: 1.5rem; }
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.9fr);
+  gap: 1.5rem;
+  align-items: stretch;
+  margin-top: 1rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--text-1);
+  font-size: 0.78rem;
+  margin-bottom: 0.75rem;
+}
+
+.hero h1 {
+  margin-top: 0;
+  font-size: clamp(2.5rem, 6vw, 4.4rem);
+  line-height: 0.95;
+}
+
+.hero h1::before { content: none; }
+
+.hero-copy {
+  padding: 1.6rem;
+  border: 1px solid var(--border-color);
+  background:
+    radial-gradient(circle at top right, rgba(210, 94, 44, 0.18), transparent 35%),
+    linear-gradient(135deg, var(--bg-1), transparent 70%);
+  border-radius: 24px;
+}
+
+.lede {
+  font-size: 1.1rem;
+  color: var(--text-0);
+  max-width: 50ch;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.hero-actions a,
+.section-heading a,
+.related-link a {
+  border-bottom: 2px solid var(--primary-color);
+}
+
+.hero-visual {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  overflow: hidden;
+  background: var(--bg-1);
+  transform: rotate(1deg);
+}
+
+.hero-visual img {
+  width: 100%;
+  height: 100%;
+  max-height: 380px;
+  object-fit: cover;
+  border-radius: 0;
+}
+
+.hero-visual-copy {
+  padding: 1rem 1.1rem 1.2rem;
+}
+
+.hero-visual-label,
+.now-strip span,
+.meta-line {
+  display: block;
+  font-family: var(--mono-text-font);
+  font-size: 0.78rem;
+  color: var(--text-1);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.hero-visual-copy strong,
+.ribbon-copy strong {
+  display: block;
+  margin: 0.35rem 0 0.4rem;
+}
+
+.hero-visual-copy p {
+  color: var(--text-1);
+  margin-bottom: 0;
+}
+
+.now-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.now-strip article,
+.feature-card,
+.note-card {
+  border: 1px solid var(--border-color);
+  border-radius: 18px;
+  padding: 1rem;
+  background: var(--bg-1);
+}
+
+.now-strip p,
+.feature-card p,
+.note-card p {
+  margin-bottom: 0;
+}
+
+.section-block {
+  margin-top: 2.5rem;
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+}
+
+.section-heading h2::before,
+.feature-card h3::before,
+.note-card h3::before {
+  content: none;
+}
+
+.feature-grid,
+.notes-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.feature-card,
+.note-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.feature-card-top h3,
+.note-card h3 {
+  margin: 0.25rem 0 0;
+}
+
+.meta-line {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.status-pill,
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.78rem;
+  color: var(--text-1);
+  background: var(--bg-0);
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.related-link {
+  color: var(--text-1);
+  font-size: 0.92rem;
+}
+
+.related-link a {
+  margin-left: 0.35rem;
+}
+
+.photo-ribbon {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.ribbon-card {
+  display: block;
+  border: 1px solid var(--border-color);
+  background: var(--bg-1);
+  border-radius: 22px;
+  overflow: hidden;
+}
+
+.ribbon-card:nth-child(2) {
+  transform: translateY(18px);
+}
+
+.ribbon-card img {
+  width: 100%;
+  height: 260px;
+  object-fit: cover;
+  border-radius: 0;
+}
+
+.ribbon-copy {
+  padding: 0.9rem 1rem 1rem;
+}
+
+.ribbon-copy span {
+  color: var(--text-1);
+  font-size: 0.92rem;
+}
+
+@media (max-width: 900px) {
+  .hero,
+  .feature-grid,
+  .notes-grid,
+  .photo-ribbon,
+  .now-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-visual,
+  .ribbon-card:nth-child(2) {
+    transform: none;
+  }
+}
 </style>

--- a/src/pages/notes/[slug].astro
+++ b/src/pages/notes/[slug].astro
@@ -9,6 +9,14 @@ export async function getStaticPaths() {
 
 const { note } = Astro.props;
 const { Content } = await render(note);
+const projects = await getCollection('projects');
+const photos = await getCollection('photos');
+const relatedProject = note.data.related_project
+  ? projects.find((project) => project.slug === note.data.related_project)
+  : undefined;
+const relatedPhoto = note.data.related_photo
+  ? photos.find((photo) => photo.slug === note.data.related_photo)
+  : undefined;
 ---
 
 <BaseLayout title={`${note.data.title} | Cameron Durham`}>
@@ -23,9 +31,21 @@ const { Content } = await render(note);
       )}
     </header>
 
+    {note.data.hero_image_url && (
+      <img class="hero-image" src={note.data.hero_image_url} alt={note.data.title} loading="eager" />
+    )}
+
     <div class="note-content">
       <Content />
     </div>
+
+    {(relatedProject || relatedPhoto) && (
+      <aside class="related-panel">
+        <h2>Related</h2>
+        {relatedProject && <p><a href={`/projects#${relatedProject.slug}`}>{relatedProject.data.title}</a></p>}
+        {relatedPhoto && <p><a href={`/photos#${relatedPhoto.slug}`}>{relatedPhoto.data.title}</a></p>}
+      </aside>
+    )}
 
     <footer class="note-footer">
       <a href="/notes">← Back to notes</a>
@@ -36,7 +56,27 @@ const { Content } = await render(note);
 <style>
 .note-header { border-bottom: 1px solid var(--border-color); padding-bottom: 1rem; margin-bottom: 1.5rem; }
 .note-header h1 { margin: 0 0 0.5rem 0; }
+.hero-image {
+  width: 100%;
+  max-height: 420px;
+  object-fit: cover;
+  margin-bottom: 1.5rem;
+  border: 1px solid var(--border-color);
+}
 .tags { margin-top: 0.75rem; display: flex; flex-wrap: wrap; gap: 0.5rem; }
 .tag { background: var(--bg-1); border: 1px solid var(--border-color); border-radius: 4px; padding: 0.15rem 0.45rem; font-size: 0.8rem; color: var(--text-1); }
+.related-panel {
+  margin-top: 2rem;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  background: var(--bg-1);
+}
+.related-panel h2 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+.related-panel h2::before { content: none; }
+.related-panel p:last-child { margin-bottom: 0; }
 .note-footer { border-top: 1px solid var(--border-color); margin-top: 2rem; padding-top: 1rem; }
 </style>

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -5,6 +5,8 @@ import { getCollection } from 'astro:content';
 const notes = (await getCollection('notes')).sort((a, b) =>
   new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
 );
+const projects = await getCollection('projects');
+const projectMap = new Map(projects.map((project) => [project.slug, project]));
 ---
 
 <BaseLayout title="Notes | Cameron Durham">
@@ -19,6 +21,12 @@ const notes = (await getCollection('notes')).sort((a, b) =>
         <h2><a href={`/notes/${note.slug}`}>{note.data.title}</a></h2>
         <time datetime={note.data.date}>{note.data.date}</time>
         <p>{note.data.summary}</p>
+        {note.data.related_project && (
+          <p class="related-link">
+            Related project:
+            <a href={`/projects#${note.data.related_project}`}>{projectMap.get(note.data.related_project)?.data.title}</a>
+          </p>
+        )}
         {note.data.tags.length > 0 && (
           <p class="tags">
             {note.data.tags.map(tag => <span class="tag">{tag}</span>)}
@@ -37,6 +45,8 @@ const notes = (await getCollection('notes')).sort((a, b) =>
 .note-item h2 { margin-bottom: 0.5rem; }
 .note-item h2::before { content: none; }
 .note-item time { display: block; margin-bottom: 0.75rem; }
+.related-link { margin-top: 0.75rem; color: var(--text-1); }
+.related-link a { margin-left: 0.3rem; }
 .tags { margin-top: 0.75rem; display: flex; flex-wrap: wrap; gap: 0.5rem; }
 .tag { background: var(--bg-1); border: 1px solid var(--border-color); border-radius: 4px; padding: 0.15rem 0.45rem; font-size: 0.8rem; color: var(--text-1); }
 </style>

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -3,36 +3,111 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 
 const photos = (await getCollection('photos')).sort((a, b) => a.data.weight - b.data.weight);
+const projects = await getCollection('projects');
+const notes = await getCollection('notes');
+const projectMap = new Map(projects.map((project) => [project.slug, project]));
+const noteMap = new Map(notes.map((note) => [note.slug, note]));
 ---
 
 <BaseLayout title="Photos | Cameron Durham">
-  <h1>Photos</h1>
-  <p class="photos-intro">A collection of some photography from art school and personal travel.</p>
+  <h1>Visual Notebook</h1>
+  <p class="photos-intro">
+    A small set of visual references, photographic studies, and images that keep the rest of the site from feeling too sterile.
+  </p>
   <div class="photos-grid">
-    {photos.map(photo => (
-      <a href={photo.data.link} target="_blank" rel="noopener noreferrer" class="photo-card">
-        <div class="photo-image-container">
-          <img src={photo.data.image_url} alt={photo.data.title} loading="lazy" />
-        </div>
-        <div class="photo-info">
-          <h3>{photo.data.title}</h3>
-          <p>{photo.data.description}</p>
-        </div>
-      </a>
-    ))}
+    {photos.map((photo) => {
+      const relatedProject = photo.data.related_project ? projectMap.get(photo.data.related_project) : undefined;
+      const relatedNote = photo.data.related_note ? noteMap.get(photo.data.related_note) : undefined;
+      return (
+        <article class="photo-card" id={photo.slug}>
+          <a href={photo.data.link} target="_blank" rel="noopener noreferrer" class="photo-image-container">
+            <img src={photo.data.image_url} alt={photo.data.title} loading="lazy" />
+          </a>
+          <div class="photo-info">
+            <div class="photo-heading">
+              <h3>{photo.data.title}</h3>
+              {(photo.data.location || photo.data.year) && (
+                <p class="photo-meta">
+                  {[photo.data.location, photo.data.year].filter(Boolean).join(' · ')}
+                </p>
+              )}
+            </div>
+            <p>{photo.data.description}</p>
+            {photo.data.story && <p class="photo-story">{photo.data.story}</p>}
+            {photo.data.tags.length > 0 && (
+              <div class="pill-row">
+                {photo.data.tags.map((tag) => <span class="pill">{tag}</span>)}
+              </div>
+            )}
+            {(relatedProject || relatedNote) && (
+              <div class="related-row">
+                {relatedProject && <a href={`/projects#${relatedProject.slug}`}>Project: {relatedProject.data.title}</a>}
+                {relatedNote && <a href={`/notes/${relatedNote.slug}`}>Note: {relatedNote.data.title}</a>}
+              </div>
+            )}
+          </div>
+        </article>
+      );
+    })}
   </div>
 </BaseLayout>
 
 <style>
 .photos-intro { margin-bottom: 2rem; color: var(--text-1); }
-.photos-grid { display: grid; gap: 24px; padding: 12px 0; grid-template-columns: repeat(auto-fill, minmax(400px, 1fr)); }
+.photos-grid { display: grid; gap: 24px; padding: 12px 0; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); }
 @media (max-width: 640px) { .photos-grid { grid-template-columns: 1fr; } }
-.photo-card { background: var(--bg-1); border: 2px solid var(--border-color); border-radius: 10px; overflow: hidden; display: block; }
-.photo-card:hover { background: transparent; }
-.photo-image-container { width: 100%; height: 300px; overflow: hidden; }
+.photo-card {
+  background:
+    linear-gradient(180deg, rgba(210, 94, 44, 0.08), transparent 18%),
+    var(--bg-1);
+  border: 1px solid var(--border-color);
+  border-radius: 18px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.photo-image-container { width: 100%; height: 300px; overflow: hidden; display: block; }
 .photo-image-container img { width: 100%; height: 100%; object-fit: cover; }
 .photo-info { padding: 0 24px 24px; }
-.photo-info h3 { margin-top: 0.7em; font-size: 1rem; font-weight: 600; }
+.photo-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-top: 0.9rem;
+}
+.photo-info h3 { margin-top: 0; font-size: 1rem; font-weight: 600; }
 .photo-info h3::before { content: none; }
+.photo-meta {
+  font-family: var(--mono-text-font);
+  font-size: 0.78rem;
+  color: var(--text-2);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
 .photo-info p { margin-top: 0.5em; font-size: 0.9rem; color: var(--text-1); }
+.photo-story { color: var(--text-0); }
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.8rem;
+}
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.78rem;
+  color: var(--text-1);
+  background: var(--bg-0);
+}
+.related-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.9rem;
+  font-size: 0.9rem;
+}
 </style>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -3,32 +3,135 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 
 const projects = (await getCollection('projects')).sort((a, b) => a.data.weight - b.data.weight);
+const notes = await getCollection('notes');
+const noteMap = new Map(notes.map((note) => [note.slug, note]));
+
+const featuredProjects = projects.filter((project) => project.data.featured);
+const archiveProjects = projects.filter((project) => !project.data.featured);
 ---
 
 <BaseLayout title="Projects | Cameron Durham">
   <h1>Projects</h1>
-  <div class="projects-list">
-    {projects.map(project => (
-      <article class="project-item">
-        <h2>
-          {project.data.link ? (
-            <a href={project.data.link} target="_blank" rel="noopener noreferrer">{project.data.title}</a>
-          ) : (
-            project.data.title
+  <p class="intro">
+    A mix of public tools, older systems projects, and recent experiments around Linux, cars, and developer workflows.
+  </p>
+
+  <section class="project-section">
+    <h2>Featured</h2>
+    <div class="projects-grid">
+      {featuredProjects.map((project) => {
+        const relatedNote = project.data.related_note ? noteMap.get(project.data.related_note) : undefined;
+        return (
+          <article class="project-card" id={project.slug}>
+            <div class="project-header">
+              <div>
+                <p class="meta-line">
+                  <time datetime={project.data.date}>{project.data.date}</time>
+                  {project.data.status && <span class="status-pill">{project.data.status}</span>}
+                </p>
+                <h3>
+                  {project.data.link ? (
+                    <a href={project.data.link} target="_blank" rel="noopener noreferrer">{project.data.title}</a>
+                  ) : (
+                    project.data.title
+                  )}
+                </h3>
+              </div>
+            </div>
+            <p>{project.data.description}</p>
+            {project.data.tags.length > 0 && (
+              <div class="pill-row">
+                {project.data.tags.map((tag) => <span class="pill">{tag}</span>)}
+              </div>
+            )}
+            {relatedNote && (
+              <p class="related-link">Related note: <a href={`/notes/${relatedNote.slug}`}>{relatedNote.data.title}</a></p>
+            )}
+          </article>
+        );
+      })}
+    </div>
+  </section>
+
+  <section class="project-section">
+    <h2>Archive</h2>
+    <div class="projects-list">
+      {archiveProjects.map((project) => (
+        <article class="project-item" id={project.slug}>
+          <h3>
+            {project.data.link ? (
+              <a href={project.data.link} target="_blank" rel="noopener noreferrer">{project.data.title}</a>
+            ) : (
+              project.data.title
+            )}
+          </h3>
+          <p class="meta-line">
+            <time datetime={project.data.date}>{project.data.date}</time>
+            {project.data.status && <span class="status-pill">{project.data.status}</span>}
+          </p>
+          <p>{project.data.description}</p>
+          {project.data.tags.length > 0 && (
+            <div class="pill-row">
+              {project.data.tags.map((tag) => <span class="pill">{tag}</span>)}
+            </div>
           )}
-        </h2>
-        <time datetime={project.data.date}>{project.data.date}</time>
-        <p>{project.data.description}</p>
-      </article>
-    ))}
-  </div>
+        </article>
+      ))}
+    </div>
+  </section>
 </BaseLayout>
 
 <style>
+.intro { margin-bottom: 2rem; color: var(--text-1); max-width: 58ch; }
+.project-section { margin-bottom: 2.5rem; }
+.project-section h2::before, .project-card h3::before, .project-item h3::before { content: none; }
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+.project-card {
+  border: 1px solid var(--border-color);
+  border-radius: 18px;
+  padding: 1rem;
+  background:
+    linear-gradient(180deg, rgba(210, 94, 44, 0.08), transparent 22%),
+    var(--bg-1);
+}
+.meta-line {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--text-1);
+  font-family: var(--mono-text-font);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+}
+.status-pill, .pill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.78rem;
+  color: var(--text-1);
+  background: var(--bg-0);
+}
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.9rem;
+}
+.related-link {
+  margin-top: 0.9rem;
+  color: var(--text-1);
+}
+.related-link a { margin-left: 0.25rem; }
 .projects-list { display: flex; flex-direction: column; gap: 2rem; }
 .project-item { border-bottom: 1px solid var(--border-color); padding-bottom: 2rem; }
 .project-item:last-child { border-bottom: none; }
-.project-item h2 { margin-bottom: 0.5rem; }
-.project-item h2::before { content: none; }
-.project-item time { display: block; margin-bottom: 0.75rem; }
+.project-item h3 { margin-bottom: 0.4rem; }
 </style>


### PR DESCRIPTION
## Summary
- redesign the homepage around recent experiments, field notes, and a visual notebook
- extend content schemas so projects, notes, and photos can cross-link and carry richer metadata
- add recent public work entries and upgrade the projects and photos pages to surface related content

## Testing
- npm run build